### PR TITLE
Update workflow dependencies

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Go
       uses: actions/setup-go@v3

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,9 +10,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Set up Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: 1.17
+      uses: actions/setup-go@v3
 
     - name: Run
       run: go run cmd/Lux/Lux.go

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,5 +12,5 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
 
-    - name: Run
+    - name: Run Lux
       run: go run cmd/Lux/Lux.go


### PR DESCRIPTION
- Updates [actions/checkout](https://github.com/actions/checkout) to `v3` from `v2`.
- Updates [actions/setup-go](https://github.com/actions/setup-go) to `v3` from `v2`.
- Removes the hardcoded Go version so the workflow can now always build on the latest stable version of Go.
- Add 'Lux' to command name to clarify what the last section of the workflow is doing.
